### PR TITLE
Rename RSSlink to RSSLink

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -23,9 +23,9 @@
 {{ with .Site.Params.bing_verify }}<meta name="msvalidate.01" content="{{ . }}">{{ end }}
 
 <link rel="canonical" href="{{ .Permalink }}">
-{{ if .RSSlink }}
-  <link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-  <link href="{{ .RSSlink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
+{{ if .RSSLink }}
+  <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+  <link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
 {{ end }}
 <!-- http://t.co/dKP3o1e -->
 <meta name="HandheldFriendly" content="True">


### PR DESCRIPTION
The former will be deprecated and eventually removed from Hugo.

Note: Currently both of them exist in Hugo, which is the reason for the cleanup.